### PR TITLE
docs: fix setHook examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,9 +711,9 @@ await tile38.set('fleet', 'bus').point(33.5123001, -112.2693001).exec();
 **Geosearch**
 | | |
 |--|--|
-| `.nearby(name, endpoint)` | |
-| `.within(name, endpoint)` | |
-| `.intersects(name, endpoint)` | |
+| `.nearby(name)` | |
+| `.within(name)` | |
+| `.intersects(name)` | |
 
 **Options**
 | | |


### PR DESCRIPTION
I believe the `endpoint` in the updated lines is not a part of the function signature